### PR TITLE
Check for presense of html editor cookie to include for first time users

### DIFF
--- a/dev/hesh.dev.js
+++ b/dev/hesh.dev.js
@@ -18,7 +18,7 @@
 		var postID = document.getElementById('post_ID') != null ? document.getElementById('post_ID').value : 0;
 		var tab_html = document.getElementById('content-html');
 		var tab_tmce = document.getElementById('content-tmce');
-		var visualEditor = document.cookie.indexOf('editor%3Dhtml') !== -1 ? false : true;
+		var visualEditor = document.cookie.indexOf('editor%3Dhtml') === -1;
 		var visualEditorEnabled = document.getElementById('content-tmce') != null;
 		var toolbar = document.getElementById('ed_toolbar');
 		var fullscreenBox = document.getElementById('wp-content-editor-container');

--- a/dev/hesh.dev.js
+++ b/dev/hesh.dev.js
@@ -18,7 +18,7 @@
 		var postID = document.getElementById('post_ID') != null ? document.getElementById('post_ID').value : 0;
 		var tab_html = document.getElementById('content-html');
 		var tab_tmce = document.getElementById('content-tmce');
-		var visualEditor = document.cookie.indexOf('editor%3Dtinymce') !== -1;
+		var visualEditor = document.cookie.indexOf('editor%3Dhtml') !== -1 ? false : true;
 		var visualEditorEnabled = document.getElementById('content-tmce') != null;
 		var toolbar = document.getElementById('ed_toolbar');
 		var fullscreenBox = document.getElementById('wp-content-editor-container');


### PR DESCRIPTION
The problem occurs only for users that have never opened the text editor which sets the `editor%3Dtinymce` cookie. Instead of looking for the absence of the `editor%3Dtinymce` you should look for the presence of `editor%3Dhtml` to account for users not having that cookie set.
https://wordpress.org/support/topic/text-editor-incorrectly-checks-for-cookie-for-first-time-user

Otherwise there is an javascript error thrown and this plugin fails to initialize resulting in both the visual and text editor being rendered right after one another instead of just one depending on the active tab. 