### PR TITLE
Add 'editor' to 'heshjs' script dependencies.

### DIFF
--- a/html-editor-syntax-highlighter.php
+++ b/html-editor-syntax-highlighter.php
@@ -50,7 +50,7 @@ class wp_html_editor_syntax {
 		wp_register_script( 'codemirror', HESH_LIBS.'codemirror.min.js', false, $ver, true );
 		wp_enqueue_script( 'codemirror' );
 
-		wp_register_script( 'heshjs', HESH_LIBS.'hesh.min.js', array('codemirror'), $ver, true );
+		wp_register_script( 'heshjs', HESH_LIBS.'hesh.min.js', array('codemirror', 'editor'), $ver, true );
 		wp_enqueue_script( 'heshjs' );
 
 	}


### PR DESCRIPTION
If WordPress has been told to disable admin script concatenation then it is likely that the editor script will be loaded after hesh.

https://wordpress.org/support/topic/typeerror-f-is-undefined-need-editor-js-dependency/